### PR TITLE
infinite scolling on team page

### DIFF
--- a/scoreboard/src/app/page-team/page-team.component.html
+++ b/scoreboard/src/app/page-team/page-team.component.html
@@ -54,7 +54,7 @@
 </table>
 
 <div class="text-center">
-	<a (click)="loadMore()" class="href btn btn-default" *ngIf="loading == 0 && tickInfosLength < currentTick">load more</a>
+	<span #loadMoreSpinner [hidden]="tickInfosLength >= currentTick" class="fas fa-spinner fa-spin"></span>
 </div>
 <br/>
 

--- a/scoreboard/src/app/page-team/page-team.component.less
+++ b/scoreboard/src/app/page-team/page-team.component.less
@@ -54,3 +54,7 @@ tablelinecells, app-table-service-header-cell {
 	height: 280px;
 	width: calc(100vw - 28px);
 }
+
+.fa-spinner[hidden] {
+	display: none
+}


### PR DESCRIPTION
While the 'load more' button might reduce requests and stress a bit on the API server, it's just not very convenient for the user.
This PR replaces the button with a spinner. Whenever this spinner is visible (detected using a `IntersectionObserver`) more ticks are loaded.
The 500ms interval is just needed for big screens (e.g. 4K) to fill the whole page and not stop loading after the first batch.
The `scrollBy(-1)` is needed when you naviate from the bottom of the scoreboard to the team page, the browser stays at scrolled down all the way even when adding new tick rows. To prevent loading infinitely without user interaction scroll a bit up. 