### PR TITLE
show game not started and first tick correctly

### DIFF
--- a/scoreboard/src/app/current-tick/current-tick.component.html
+++ b/scoreboard/src/app/current-tick/current-tick.component.html
@@ -1,10 +1,12 @@
-<div class="current-tick" *ngIf="backend.currentState.current_tick > 0">
+<div class="current-tick">
 	<p class="tick">Tick {{backend.currentState.current_tick}}</p>
 	<p class="time">
 		&nbsp;
-		<span *ngIf="backend.currentState.state == GameStates.RUNNING && currentTime > 0">{{formatRemainingTime(currentTime)}}</span>
+		<span *ngIf="currentTime > 0 && (backend.currentState.state == GameStates.RUNNING || backend.currentState.current_tick <= 0)">
+			{{formatRemainingTime(currentTime)}}
+		</span>
 		<span *ngIf="backend.currentState.state == GameStates.SUSPENDED" class="label label-warning">game suspended</span>
-		<span *ngIf="backend.currentState.state == GameStates.STOPPED && backend.currentState.current_tick > 0" class="label label-success">game is over</span>
-		<span *ngIf="backend.currentState.state == GameStates.STOPPED && backend.currentState.current_tick <= 0" class="label label-danger">not started</span>
+		<span *ngIf="backend.currentState.state == GameStates.STOPPED && backend.currentState.current_tick >= 0" class="label label-success">game is over</span>
+		<span *ngIf="backend.currentState.state == GameStates.STOPPED && backend.currentState.current_tick < 0" class="label label-danger">not started</span>
 	</p>
 </div>

--- a/scoreboard/src/app/current-tick/current-tick.component.less
+++ b/scoreboard/src/app/current-tick/current-tick.component.less
@@ -12,4 +12,8 @@
 		font-size: 18px;
 		margin-top: 15px;
 	}
+
+	.time span {
+		margin-left: 5px;
+	}
 }

--- a/scoreboard/src/app/scoretable/scoretable.component.html
+++ b/scoreboard/src/app/scoretable/scoretable.component.html
@@ -3,10 +3,10 @@
 	<tr>
 		<th colspan="3" class="headercell">
 			<h4>
-				Results from:
+				{{info.tick < 0 ? 'No results yet' : 'Results from:'}}
 				<a class="btn btn-link" (click)="showTick(shownTick-1)" title="Previous tick"
 				   *ngIf="shownTick > 0"><i class="fas fa-chevron-left"></i></a>
-				Tick {{info.tick < 0 ? '0' : info.tick }}
+				{{info.tick < 0 ? '' : 'Tick ' + info.tick}}
 				<a class="btn btn-link" (click)="showTick(shownTick+1)" title="Next tick"
 				   *ngIf="shownTick < backend.currentState.scoreboard_tick"><i class="fas fa-chevron-right"></i></a>
 				<a class="btn btn-link" (click)="showTick(backend.currentState.scoreboard_tick)" title="Go to current tick"


### PR DESCRIPTION
I'm not quite sure how the SaarCTF handles this (but the fact that [tick -1](https://ctf.saarland/static/scoreboard/api/scoreboard_round_-1.json) exists tells me it can't be that different).
In FAUST CTF tick -1 is active before the game starts and then tick 0 is the first tick of the game an ends one tick duration after the game has started. Before the CTF started and during this tick 0 it would be nice if the scoreboard shows something useful.

If you look at the old HTML you will notice that 'not started' can actually never be shown because of the top `*ngIf`.
This PR removes that `*ngIf`. Also the time left until the game starts will be show in addition to the 'not started' label (but this needs a small margin).
Additionally during the tick 0 and before the top left of the scoreboard table should not say 'Tick 0' instead it now shows 'No results yet' 